### PR TITLE
Fix logic around builtin detection

### DIFF
--- a/fmetrics.cc
+++ b/fmetrics.cc
@@ -114,7 +114,7 @@ pass_fmetrics :: execute (function *fun)
 	{
 	  gimple *call = gsi_stmt (i);
 	  if (!gimple_call_builtin_p (call, BUILT_IN_OBJECT_SIZE)
-	      || !gimple_call_builtin_p (call, BUILT_IN_DYNAMIC_OBJECT_SIZE))
+	      && !gimple_call_builtin_p (call, BUILT_IN_DYNAMIC_OBJECT_SIZE))
 	    continue;
 
 	  tree lhs = gimple_call_lhs (call);


### PR DESCRIPTION
Only bail out early if the call is NEITHER type of builtin.

Without this change, for me no fortification is ever detected.

`gcc -fplugin=fmetrics.so -fplugin-arg-fmetrics-project=TEST tests/builtin-dynamic-object-size-0.c -c -o tests/builtin-dynamic-object-size-0.o -D_FORTIFY_SOURCE=3 -O2`

Without the change:
```TEST:: 0:0:0```

With the change:
```TEST:: 43:2:31```
