### PR TITLE
fmetrics: cleanup after SSA updates

### DIFF
--- a/fmetrics.cc
+++ b/fmetrics.cc
@@ -6,6 +6,7 @@
 #include <builtins.h>
 #include <context.h>
 #include <tree.h>
+#include <tree-cfgcleanup.h>
 #include <tree-object-size.h>
 #include <tree-pass.h>
 #include <tree-pretty-print.h>
@@ -107,6 +108,8 @@ unsigned int
 pass_fmetrics :: execute (function *fun)
 {
   basic_block bb;
+  unsigned int todo = 0;
+
   FOR_EACH_BB_FN (bb, fun)
     {
       gimple_stmt_iterator i;
@@ -146,5 +149,8 @@ pass_fmetrics :: execute (function *fun)
 
   fini_object_sizes ();
 
-  return 0;
+  if (cleanup_tree_cfg (TODO_update_ssa_only_virtuals))
+    todo |= TODO_update_ssa_only_virtuals;
+
+  return todo;
 }


### PR DESCRIPTION
We call `compute_builtin_object_size` which isn't side-effect free, as it may call e.g. `early_object_sizes_execute_one` which updates SSA.

With checking, we get an ICE because we were missing the cleanup:
```
(gdb) frame 2
 0x00005555555d0c9a in execute_todo (flags=64) at /usr/src/debug/sys-devel/gcc-15.0.9999/gcc-15.0.9999/gcc/passes.cc:2150
2150        gcc_assert (flags & TODO_update_ssa_any);
```

Closes: https://github.com/siddhesh/fortify-metrics/issues/3